### PR TITLE
Asignar vigencia de Plan de Adquisiciones

### DIFF
--- a/app/scripts/controllers/necesidad/solicitud_necesidad.js
+++ b/app/scripts/controllers/necesidad/solicitud_necesidad.js
@@ -44,7 +44,6 @@ angular
           JefeDepSolicitanteId: undefined,
           SupervisorId: undefined,
         },
-        Vigencia: new Date().getFullYear() + "",
         Valor: 0,
       };
       //inicializar objetos necesidad
@@ -799,6 +798,7 @@ angular
                       self.planes_anuales = [];
                       self.planes_anuales.push(res.data);
                       $scope.solicitudNecesidad.vigencia = res.data.vigencia;
+                      self.Necesidad.Vigencia = res.data.vigencia.toString();
                       $scope.solicitudNecesidad.planadquisicion = $scope.solicitudNecesidad.planes_anuales[0];
                     }
                   });
@@ -820,6 +820,7 @@ angular
                       self.planes_anuales = [];
                       self.planes_anuales.push(res.data);
                       $scope.solicitudNecesidad.vigencia = res.data.vigencia;
+                      self.Necesidad.Vigencia = res.data.vigencia.toString();
                       $scope.solicitudNecesidad.planadquisicion = $scope.solicitudNecesidad.planes_anuales[0];
                     }
                   });

--- a/app/scripts/services/necesidad/necesidad_service.js
+++ b/app/scripts/services/necesidad/necesidad_service.js
@@ -287,7 +287,6 @@ angular.module('contractualClienteApp')
               JefeDepSolicitanteId: undefined,
               SupervisorId: undefined
             },
-            Vigencia: 2019 + "",
             Valor: 0,
             DiasDuracion: 0,
 


### PR DESCRIPTION
En concordancia con traer los datos del plan de adquisiciones se cambia la vigencia de la necesidad al seleccionar el correspondiente plan de adquisiciones.

Tiene que ver con: udistrital/necesidades_cliente#271

**Nota:** Hay cosas que se pueden optimizar en funciones, sin embargo se emite el Pull Request por el tema de funcionalidad